### PR TITLE
Add bcache-export-cached helper to export CACHED_UUID and CACHED_LABEL

### DIFF
--- a/69-bcache.rules
+++ b/69-bcache.rules
@@ -23,10 +23,9 @@ RUN+="bcache-register $tempnode"
 LABEL="bcache_backing_end"
 
 # Cached devices: symlink
-DRIVER=="bcache", ENV{CACHED_UUID}=="?*", \
-        SYMLINK+="bcache/by-uuid/$env{CACHED_UUID}"
-DRIVER=="bcache", ENV{CACHED_LABEL}=="?*", \
-        SYMLINK+="bcache/by-label/$env{CACHED_LABEL}"
+IMPORT{program}="bcache-export-cached $tempnode"
+ENV{CACHED_UUID}=="?*", SYMLINK+="bcache/by-uuid/$env{CACHED_UUID}"
+ENV{CACHED_LABEL}=="?*", SYMLINK+="bcache/by-label/$env{CACHED_LABEL}"
 
 LABEL="bcache_end"
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: make-bcache probe-bcache bcache-super-show bcache-register
 
 install: make-bcache probe-bcache bcache-super-show
 	$(INSTALL) -m0755 make-bcache bcache-super-show	$(DESTDIR)${PREFIX}/sbin/
-	$(INSTALL) -m0755 probe-bcache bcache-register		$(DESTDIR)$(UDEVLIBDIR)/
+	$(INSTALL) -m0755 probe-bcache bcache-register bcache-export-cached $(DESTDIR)$(UDEVLIBDIR)/
 	$(INSTALL) -m0644 69-bcache.rules	$(DESTDIR)$(UDEVLIBDIR)/rules.d/
 	$(INSTALL) -m0644 -- *.8 $(DESTDIR)${PREFIX}/share/man/man8/
 	$(INSTALL) -D -m0755 initramfs/hook	$(DESTDIR)/usr/share/initramfs-tools/hooks/bcache

--- a/bcache-export-cached
+++ b/bcache-export-cached
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# This program reads the bcache superblock on bcacheX slaves to extract the
+# dev.uuid and dev.label which refer to a specific backing device.
+#
+# It integrates with udev 'import' by writing CACHED_UUID=X and optionally
+# CACHED_LABEL=X for the backing device of the provided bcache device.
+# Ignore caching devices by skipping unless sb.version=1
+#
+# There is 1 and only 1 backing device (slaves/*) for a bcache device.
+
+TEMPNODE=${1}  # /dev/bcacheN
+DEVNAME=${TEMPNODE##*/}  # /dev/bcacheN -> bcacheN
+
+for slave in "/sys/class/block/$DEVNAME/slaves"/*; do
+    [ -d "$slave" ] || continue
+    bcache-super-show "/dev/${slave##*/}" |
+       awk '$1 == "sb.version" { sbver=$2; }
+            $1 == "dev.uuid" { uuid=$2; }
+            $1 == "dev.label" && $2 != "(empty)" { label=$2; }
+            END {
+                if (sbver == 1 && uuid) {
+                    print("CACHED_UUID=" uuid)
+                    if (label) print("CACHED_LABEL=" label)
+                    exit(0)
+                }
+                exit(1);
+            }'
+    # awk exits 0 if it found a backing device.
+    [ $? -eq 0 ] && exit 0
+done

--- a/initcpio/install
+++ b/initcpio/install
@@ -1,6 +1,7 @@
 #!/bin/bash
 build() {
     add_module bcache
+    add_binary /usr/lib/udev/bcache-export-cached
     add_binary /usr/lib/udev/bcache-register
     add_binary /usr/lib/udev/probe-bcache
     add_file /usr/lib/udev/rules.d/69-bcache.rules

--- a/initramfs/hook
+++ b/initramfs/hook
@@ -22,6 +22,7 @@ elif [ -e /lib/udev/rules.d/69-bcache.rules ]; then
     cp -pt "${DESTDIR}/lib/udev/rules.d" /lib/udev/rules.d/69-bcache.rules
 fi
 
+copy_exec /lib/udev/bcache-export-cached
 copy_exec /lib/udev/bcache-register
 copy_exec /lib/udev/probe-bcache
 manual_add_modules bcache


### PR DESCRIPTION
Linux kernel bcache driver does not always emit a uevent[1] for when a backing
device is bound to a bcacheN device.  When this happens, the udev rule for
creating /dev/bcache/by-uuid or /dev/bcache/by-label symlinks does not fire
and removes any persistent symlink to a specific backing device since the bcache
minor numbers (bcache0, 1, 2) are not guaranteed across reboots[2][3].

This script reads the superblock of the bcache device slaves, ensuring the slave
is a backing device via sb.version check, extracts the dev.uuid and dev.label
values and exports them to udev for triggering the symlink rules in the existing
rules file.

1. https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1729145
2. https://bugs.launchpad.net/bcache-tools/+bug/1728742
3. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=890446
