### PR TITLE
Don't inline crc64 for gcc-5 compatibility

### DIFF
--- a/bcache.c
+++ b/bcache.c
@@ -115,7 +115,7 @@ static const uint64_t crc_table[256] = {
 	0x9AFCE626CE85B507ULL
 };
 
-inline uint64_t crc64(const void *_data, size_t len)
+uint64_t crc64(const void *_data, size_t len)
 {
 	uint64_t crc = 0xFFFFFFFFFFFFFFFFULL;
 	const unsigned char *data = _data;


### PR DESCRIPTION
By James Cowgill, see Debian bug #777798

Original submission: http://article.gmane.org/gmane.linux.kernel.bcache.devel/2919